### PR TITLE
fixed a non-portable file include

### DIFF
--- a/Source/Base64.cpp
+++ b/Source/Base64.cpp
@@ -1,5 +1,5 @@
 //This library is horrible, go fix it u maincra
-#include "External/base64.hpp"
+#include "External/Base64.hpp"
 #include <string>
 
 static std::string const dict("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_");


### PR DESCRIPTION
changed base64.hpp to Base64.hpp to match the actual file name, in order to prevent a non-portable path to file error